### PR TITLE
Exiting `npm run dev` if Express fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,21 @@ If you're mostly working on the frontend and don't need any immediate requests t
 
 To start both together, `cd` into the `/client` cirectory and issue the `npm run dev` command. This will first start Express, then start React.
 
-# Building the docker image
+# Building the docker image and deploying
 
-TO DO
+## Prerequisites
 
-# Deploying the website
+- Install docker: https://docs.docker.com/install/
+- Set up "docker credential helpers" as described in step 7 of https://cloud.google.com/run/docs/setup
 
-TO DO
+## Building and deploying
+
+```
+cd study-buddies/
+docker build -t gcr.io/study-buddies-266004/study-buddies-img .
+docker push gcr.io/study-buddies-266004/study-buddies-img:latest
+gcloud run deploy study-buddies-img --image gcr.io/study-buddies-266004/study-buddies-img --platform managed --region us-west1
+```
 
 # Making Changes
 

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
     "main": "app.js",
     "scripts": {
         "start": "node ./bin/www",
-        "server": "nodemon --exec npm start"
+        "server": "npm start"
     },
     "dependencies": {
         "cookie-parser": "~1.4.4",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8688,6 +8688,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11663,6 +11668,15 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+    },
+    "react-places-autocomplete": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-places-autocomplete/-/react-places-autocomplete-7.2.1.tgz",
+      "integrity": "sha512-X1SRv3zJjEZ9dnfy/vlSFi8dpUZc/vW4CF7GhN46AVATNMmB1y1EwhX2aiqKVWXO1888p9l7FMJLgySPRBDMCQ==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8"
+      }
     },
     "react-router": {
       "version": "5.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
         "node-sass": "^4.13.1",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-places-autocomplete": "^7.2.1",
         "react-router-dom": "^5.1.2",
         "react-scripts": "3.3.0"
     },
@@ -21,7 +22,7 @@
         "eject": "react-scripts eject",
         "client": "npm start",
         "server": "cd ../api && npm run server",
-        "dev": "concurrently \"npm run client\" \"npm run server\""
+        "dev": "concurrently --kill-others \"npm run client\" \"npm run server\""
     },
     "eslintConfig": {
         "extends": "react-app"

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,6 +24,10 @@
         <title>React App</title>
     </head>
     <body>
+        <script
+            type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC4YLPSKd-b0RxRh5kqx8QDnf9yMDioK0Y&libraries=places"
+        ></script>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
         <!--

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -16,6 +16,13 @@ Example:
 
 */
 
+// Constrain all content to the borders
+*,
+*:before,
+*:after {
+    box-sizing: border-box;
+}
+
 .App {
     text-align: center;
 }

--- a/client/src/components/layouts/Home.js
+++ b/client/src/components/layouts/Home.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Search from "../maps/Search";
 // Home specific styling
 import "./Home.scss";
 
@@ -18,8 +19,8 @@ class Home extends React.Component {
         if (prevProps !== this.props) {
             this.setState({
                 lat: this.props.lat,
-                long: this.props.long
-            })
+                long: this.props.long,
+            });
         }
     }
 
@@ -38,9 +39,9 @@ class Home extends React.Component {
     render() {
         return (
             <div className="home_page">
-                <p>
-                    Your current coordinates are lat: {this.state.lat} and long: {this.state.long}.
-                </p>
+                <div className="content_wrapper">
+                    <Search />
+                </div>
             </div>
         );
     }

--- a/client/src/components/layouts/Home.scss
+++ b/client/src/components/layouts/Home.scss
@@ -5,4 +5,16 @@
     align-items: center;
     background-color: #787878;
     min-height: 100vh;
+    /* Might be worth transitioning to a local image in the future */
+    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+        url("https://images.unsplash.com/photo-1519155031214-e8d583928bf2?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80");
+    background-size: cover;
+
+    .content_wrapper {
+        max-width: 960px;
+        background: #fff;
+        width: 100%;
+        border-radius: 10px;
+        padding: 15px;
+    }
 }

--- a/client/src/components/maps/Search.js
+++ b/client/src/components/maps/Search.js
@@ -1,11 +1,57 @@
-import React from 'react';
+import React from "react";
+import PlacesAutocomplete, { geocodeByAddress, getLatLng } from "react-places-autocomplete";
+import "./Search.scss"; // Styling
 
 class Search extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { address: "" };
+    }
+
+    handleChange = address => {
+        this.setState({ address });
+    };
+
+    handleSelect = address => {
+        geocodeByAddress(address)
+            .then(results => getLatLng(results[0]))
+            .then(latLng => console.log("Success", latLng))
+            .catch(error => console.error("Error", error));
+    };
+
     render() {
-        return(
-            <div>
-                Results from a particular geo location & zoom, with a search term
-            </div>
+        return (
+            <PlacesAutocomplete value={this.state.address} onChange={this.handleChange} onSelect={this.handleSelect}>
+                {({ getInputProps, suggestions, getSuggestionItemProps, loading }) => (
+                    <div>
+                        <input
+                            {...getInputProps({
+                                placeholder: "Search Places ...",
+                                className: "location-search-input",
+                            })}
+                        />
+                        <div className="autocomplete-dropdown-container">
+                            {loading && <div>Loading...</div>}
+                            {suggestions.map(suggestion => {
+                                const className = suggestion.active ? "suggestion-item--active" : "suggestion-item";
+                                const style = suggestion.active
+                                    ? { backgroundColor: "#fafafa", cursor: "pointer" }
+                                    : { backgroundColor: "#ffffff", cursor: "pointer" };
+                                return (
+                                    <div
+                                        {...getSuggestionItemProps(suggestion, {
+                                            className,
+                                            style,
+                                        })}
+                                    >
+                                        <span>{suggestion.description}</span>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
+            </PlacesAutocomplete>
         );
     }
 }

--- a/client/src/components/maps/Search.scss
+++ b/client/src/components/maps/Search.scss
@@ -1,0 +1,36 @@
+.search_addr_form {
+    display: block;
+
+    .input_group {
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: flex-start;
+
+        .form_label,
+        .form_input {
+            margin: 10px 0;
+        }
+
+        .form_label {
+            font-size: 24px;
+        }
+
+        .form_input {
+            width: 100%;
+            font-size: 30px;
+            padding: 10px;
+            border-radius: 10px;
+            border: 1px solid #9b9b9b;
+            background: #ebf0fc;
+            outline: none;
+
+            &::placeholder {
+                color: #9b9b9b;
+            }
+
+            &:focus {
+                box-shadow: 0 0 3px 1px rgb(14, 126, 255);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- adding --kill-others to `concurrently`
- removing usage of nodemon since it doesn't exit if Express fails

Fixes https://github.com/cmatian/study-buddies/issues/25

Now if Cloud SQL proxy isn't running, Express will fail, then concurrently will kill the other things running, which in our case is the React server, causing everything to exit. This will allow us to discover early if there is an issue when we try to run our server.