### PR TITLE
Removing unused parameter from frontend API call

### DIFF
--- a/client/src/components/business/Rates.js
+++ b/client/src/components/business/Rates.js
@@ -56,7 +56,6 @@ class Rates extends React.Component {
         // convert cost to string to match varchar in db
         let data = {
             places_id: this.props.location.state.places_id,
-            name: this.props.location.state.name,            
             rating: this.state.starRating,
             comment: this.state.review,
             cost: this.state.estimatedCost.toString(),


### PR DESCRIPTION
The backend calls the Places API to get the location's name, so this parameter is not used.