### PR TITLE
Changing maps page layout for mobile

### DIFF
--- a/client/src/components/business/Biz.scss
+++ b/client/src/components/business/Biz.scss
@@ -1,14 +1,19 @@
 .business_detail_wrapper {
-    position: fixed;
     bottom: 0;
     left: 0;
-    max-width: 250px;
     height: 100%;
-    padding-top: 53px;
     background: #fff;
     overflow-x: hidden;
     overflow-y: auto;
     z-index: 1;
+
+    &.desktop {
+        max-width: 250px;
+    }
+
+    &.mobile {
+        max-height: 250px;
+    }
     
     .image_container {
         height: 200px;

--- a/client/src/components/business/Reserve.scss
+++ b/client/src/components/business/Reserve.scss
@@ -1,14 +1,19 @@
 .make_reservation_wrapper {
-    position: fixed;
     top: 0;
     left: 0;
-    max-width: 250px;
     height: 100%;
     width: 100%;
     background: #fff;
-    padding-top: 53px;
     overflow-y: auto;
     z-index: 1;
+
+    &.desktop {
+        max-width: 250px;
+    }
+
+    &.mobile {
+        max-height: 250px;
+    }
 
     .placeid_error {
         text-align: left;

--- a/client/src/components/layouts/Nav.js
+++ b/client/src/components/layouts/Nav.js
@@ -14,7 +14,7 @@ class Nav extends React.Component {
     render() {
         return (
             <ResponsiveLayout
-                breakPoint={767}
+                breakPoint={500}
                 renderDesktop={() => this.renderDesktopNav()}
                 renderMobile={() => (
                     <MobileNav/>

--- a/client/src/components/layouts/ResponsiveLayout.js
+++ b/client/src/components/layouts/ResponsiveLayout.js
@@ -2,7 +2,7 @@
 
 import { useWindowSize } from '../../WindowSizeContext'
 
-const ResponsiveLayout = ({ breakPoint = 414, renderMobile, renderDesktop }) => {
+const ResponsiveLayout = ({ breakPoint = 400, renderMobile, renderDesktop }) => {
   const { width } = useWindowSize()
   return width > breakPoint ? renderDesktop() : renderMobile()
 }

--- a/client/src/components/maps/Maps.js
+++ b/client/src/components/maps/Maps.js
@@ -8,6 +8,7 @@ import Biz from "../business/Biz";
 import PlaceDetail from './PlaceDetail';
 import Search from '../search/Search';
 import Filters from '../search/Filters';
+import ResponsiveLayout from "../layouts/ResponsiveLayout";
 import "./Maps.scss"; // Styling
 
 const mapStyles = {
@@ -266,6 +267,16 @@ class Maps extends React.Component {
     };
 
     render() {
+        return (
+            <ResponsiveLayout
+                breakPoint={500}
+                renderDesktop={() => this.renderParameterized(false)}
+                renderMobile={() => this.renderParameterized(true)}
+                />
+        );
+    }
+
+    renderParameterized(isMobile) {
         // console.log('this.props: ', this.props)
         const center = {
             lat: this.props.lat,
@@ -274,8 +285,10 @@ class Maps extends React.Component {
 
         const { isExpanded, isSearching } = this.state;
 
+        const modeClass = isMobile ? "mobile" : "desktop";
+
         return (
-            <div className="map_wrapper">
+            <div className={"map_wrapper " + modeClass}>
                 {isSearching &&
                     <div className="search_wrapper">
                         <span className="close_search" onClick={this.toggleSearch}>
@@ -294,13 +307,32 @@ class Maps extends React.Component {
                         </div>
                     </div>
                 }
-                <div className={"place_list_container " + (isExpanded ? "expanded" : "")}>
-                    <PlaceSelected
-                        onDetailSelect={this.onDetailSelect}
-                        place={this.state.selectedPlace}
-                        onReservationSelect={this.onReservationSelect}
-                    />
-                    <PlaceList onPlaceSelect={this.onPlaceSelect} places={this.state.places} selected={this.state.selectedIndex} hover={this.state.hoverTarget} />
+                <div className={"sidebar_container " + (isExpanded ? "expanded" : "")}>
+                    {!this.state.showBusinessDetail && !this.state.showMakeReservation &&
+                        <div className={"place_list_container"}>
+                            <PlaceSelected
+                                onDetailSelect={this.onDetailSelect}
+                                place={this.state.selectedPlace}
+                                onReservationSelect={this.onReservationSelect}
+                            />
+                            <PlaceList onPlaceSelect={this.onPlaceSelect} places={this.state.places} selected={this.state.selectedIndex} hover={this.state.hoverTarget} />
+                        </div>
+                    }
+                    {/* Business Details */}
+                    {this.state.showBusinessDetail &&
+                        <Biz
+                            selectedPlace={this.state.selectedPlace}
+                            selectedPlaceDetail={this.state.selectedPlaceDetail}
+                            selectedPlaceDistance={this.state.selectedPlaceDistance}
+                            onReservationSelect={this.onReservationSelect}
+                        />
+                    }
+
+                    {/* Reservation Form */}
+                    {this.state.showMakeReservation &&
+                        // Send all selectedPlaceDetails to the form
+                        <Reserve data={this.state.selectedPlaceDetail} />
+                    }
                 </div>
                 <div className="map_container">
                     {/* Don't show list toggle when detail/reservation menu is visible */}
@@ -325,22 +357,6 @@ class Maps extends React.Component {
                         <i className="material-icons">search</i>
                     </div>
                     <div style={mapStyles}>
-                        {/* Business Details */}
-                        {this.state.showBusinessDetail &&
-                            <Biz
-                                selectedPlace={this.state.selectedPlace}
-                                selectedPlaceDetail={this.state.selectedPlaceDetail}
-                                selectedPlaceDistance={this.state.selectedPlaceDistance}
-                                onReservationSelect={this.onReservationSelect}
-                            />
-                        }
-
-                        {/* Reservation Form */}
-                        {this.state.showMakeReservation &&
-                            // Send all selectedPlaceDetails to the form
-                            <Reserve data={this.state.selectedPlaceDetail} />
-                        }
-
                         {/* Google Map + Pins */}
                         <GoogleMap
                             bootstrapURLKeys={{ key: "AIzaSyC4YLPSKd-b0RxRh5kqx8QDnf9yMDioK0Y" }}

--- a/client/src/components/maps/Maps.scss
+++ b/client/src/components/maps/Maps.scss
@@ -4,6 +4,10 @@
     height: 100%;
     padding-top: 53px;
 
+    &.mobile {
+        flex-direction: column;
+    }
+
     .search_button {
         position: absolute;
         z-index: 1;
@@ -47,7 +51,7 @@
 
     }
 
-    .place_list_container {
+    .sidebar_container {
         flex: 0;  
         height: 100%;
         overflow-x: hidden;

--- a/client/src/components/maps/PlaceSelected.scss
+++ b/client/src/components/maps/PlaceSelected.scss
@@ -1,6 +1,5 @@
 .focus_wrapper {
     position: relative;
-    max-width: 250px;
     padding: 7.5px;
     margin: 7.5px;
     border: 1px dashed rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
I moved the Biz and Reserve elements into a shared parent with PlaceSelected, and made their layout non-fixed so that they could be moved around together. This was necessary to treat the sidebar as a single entity, which I needed to do for mobile to move everything vertical instead of horizontal. 

This has a nice side benefit of fixing a minor problem with the Reserve pane, which was slightly wider than the Biz and PlaceSelected panes and created a weird visual artifact.

Updates https://github.com/cmatian/study-buddies/issues/119