### PR TITLE
Usability fixes for saving locations

### DIFF
--- a/client/src/components/reservation/ReservationDetails.js
+++ b/client/src/components/reservation/ReservationDetails.js
@@ -558,15 +558,15 @@ class ReservationDetails extends React.Component {
                                 <h3>
                                     @{details.name}
                                     <i
-                                        className={"material-icons save_location " + (
+                                        className={"material-icons save_location noselect " + (
                                             reservation.saved_location !== null && reservation.saved_location.saved_location_id ? "gold" : ""
                                         )}
                                         title={reservation.saved_location !== null && reservation.saved_location.saved_location_id ? "Remove from Saved Locations" : "Save Location"}
                                         onClick={this.toggleSavedLocation}
                                     >
-                                        star
+                                        bookmark
                                     </i>
-                                    <i className="material-icons location_type_icon">
+                                    <i className="material-icons location_type_icon noselect">
                                         {(() => {
                                             switch (details.types[0]) {
                                                 case "cafe":

--- a/client/src/components/reservation/styles/ReservationDetails.scss
+++ b/client/src/components/reservation/styles/ReservationDetails.scss
@@ -1,3 +1,14 @@
+// https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Opera and Firefox */
+}
+
 .reservation_form {
     height: auto;
 


### PR DESCRIPTION
- Converting the star to a bookmark
- Making the bookmark icon and location type icon non-selectable